### PR TITLE
Workaround for the clippy issue

### DIFF
--- a/.github/workflows/vapoursynth.yml
+++ b/.github/workflows/vapoursynth.yml
@@ -29,6 +29,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all-targets --package sample-plugin
+        name: sample-plugin
 
   unix-tests:
     strategy:


### PR DESCRIPTION
It is now possible to view different instances of the `clippy-check` action as snippets. The name of each instance is given by the `name` parameter. It's just a temporary solution waiting for the new `Github APIs`.

I would like to thank @svartalf and @garyttierney for the help and the quick fix! :)

Thanks in advance for your review! :)