### PR TITLE
Implement deref for FormatID

### DIFF
--- a/vapoursynth/src/format.rs
+++ b/vapoursynth/src/format.rs
@@ -254,3 +254,9 @@ impl From<i32> for FormatID {
         FormatID(x)
     }
 }
+
+impl From<FormatID> for i32 {
+    fn from(x: FormatID) -> Self {
+        x.0
+    }
+}


### PR DESCRIPTION
Use case: I have a plugin where I need to
convert the color format of one clip to match another.
I can only retrieve the FormatID as a FormatID.
To pass it into convert, I need the integer representation
of that FormatId.