### PR TITLE
Fix tests on API 3.6

### DIFF
--- a/sample-plugin/src/lib.rs
+++ b/sample-plugin/src/lib.rs
@@ -403,11 +403,12 @@ make_filter_function! {
             ensure!(float == 1337f64, "{} != 1337", float);
         }
         ensure!(data == &b"asd"[..], "{:?} != {:?}", data, &b"asd"[..]);
-        ensure!(
-            node.info().num_frames == Property::Constant(1),
-            "{:?} != 1",
-            node.info().num_frames
-        );
+
+        // Only one frame, this is to pass tests for all API versions
+        // Use `Node.info()`
+        ensure!(node.get_frame(0).is_ok(), "couldn't get frame 0");
+        ensure!(node.get_frame(1).is_err(), "frame count > 1");
+
         ensure!(frame.width(0) == 320, "{} != 320", frame.width(0));
         ensure!(out.get::<i64>("val").map(|x| x == 10).unwrap_or(false), "Incorrect function");
         ensure!(optional_int.is_some(), "optional_int is missing");

--- a/vapoursynth/examples/vspipe.rs
+++ b/vapoursynth/examples/vspipe.rs
@@ -24,7 +24,7 @@ mod inner {
 
     use anyhow::{anyhow, bail, ensure, Context, Error};
 
-    use self::clap::{App, Arg};
+    use self::clap::{Command, Arg};
     use self::num_rational::Ratio;
     use self::vapoursynth::prelude::*;
     use super::*;
@@ -569,7 +569,7 @@ mod inner {
     }
 
     pub fn run() -> anyhow::Result<()> {
-        let matches = App::new("vspipe-rs")
+        let matches = Command::new("vspipe-rs")
             .about("A Rust implementation of vspipe")
             .author("Ivan M. <yalterz@gmail.com>")
             .arg(

--- a/vapoursynth/examples/vspipe.rs
+++ b/vapoursynth/examples/vspipe.rs
@@ -24,7 +24,7 @@ mod inner {
 
     use anyhow::{anyhow, bail, ensure, Context, Error};
 
-    use self::clap::{Command, Arg};
+    use self::clap::{Arg, Command};
     use self::num_rational::Ratio;
     use self::vapoursynth::prelude::*;
     use super::*;

--- a/vapoursynth/src/tests.rs
+++ b/vapoursynth/src/tests.rs
@@ -961,7 +961,7 @@ mod need_api {
             let (tx, rx) = channel();
             *SENDER.lock().unwrap() = Some(tx);
 
-            api.add_message_handler_trivial(|message_type, message| {
+            let id = api.add_message_handler_trivial(|message_type, message| {
                 let guard = SENDER.lock().unwrap();
                 let tx = guard.as_ref().unwrap();
                 assert_eq!(tx.send((message_type, message.to_owned())), Ok(()));
@@ -999,10 +999,9 @@ mod need_api {
                     CString::new("test critical message").unwrap()
                 ))
             );
-        }
 
-        #[allow(deprecated)]
-        api.clear_message_handler();
+            api.remove_message_handler(id);
+        }
     }
 
     #[test]


### PR DESCRIPTION
The old `setMessageHandler` API seemingly does nothing when passed a null function pointer.
Also updated example to fix deprecation warnings from clap.

Fixes #15 