### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "vapoursynth",
     "vapoursynth-sys",

--- a/sample-plugin/src/lib.rs
+++ b/sample-plugin/src/lib.rs
@@ -1,4 +1,4 @@
-///! A sample VapourSynth plugin.
+//! A sample VapourSynth plugin.
 extern crate rand;
 #[macro_use]
 extern crate vapoursynth;

--- a/sample-plugin/src/lib.rs
+++ b/sample-plugin/src/lib.rs
@@ -253,17 +253,17 @@ make_filter_function! {
             bail!("Floating point formats are not supported");
         }
 
-        if width <= 0 || width > i64::from(i32::max_value()) {
+        if width <= 0 || width > i64::from(i32::MAX) {
             bail!("Invalid width");
         }
         let width = width as usize;
 
-        if height <= 0 || height > i64::from(i32::max_value()) {
+        if height <= 0 || height > i64::from(i32::MAX) {
             bail!("Invalid height");
         }
         let height = height as usize;
 
-        if length <= 0 || length > i64::from(i32::max_value()) {
+        if length <= 0 || length > i64::from(i32::MAX) {
             bail!("Invalid length");
         }
         let length = length as usize;

--- a/sample-plugin/src/lib.rs
+++ b/sample-plugin/src/lib.rs
@@ -163,6 +163,9 @@ impl<'core> Filter<'core> for RandomNoise {
             format: core.get_format(self.format_id).unwrap().into(),
             resolution: self.resolution.into(),
             framerate: self.framerate.into(),
+
+            // useless for some API versions, required for others
+            #[allow(clippy::useless_conversion)]
             num_frames: self.length.into(),
             flags: Flags::empty(),
         }]

--- a/vapoursynth/examples/vpy-info.rs
+++ b/vapoursynth/examples/vpy-info.rs
@@ -109,7 +109,7 @@ fn run() -> Result<(), Error> {
         let n = n
             .parse::<usize>()
             .context("Couldn't parse the frame number")?;
-        if n > i32::max_value() as usize {
+        if n > i32::MAX as usize {
             bail!("Frame number is too big");
         }
 

--- a/vapoursynth/examples/vspipe.rs
+++ b/vapoursynth/examples/vspipe.rs
@@ -538,7 +538,7 @@ mod inner {
             }
         }
 
-        let &(ref lock, ref cvar) = &shared_data.output_done_pair;
+        let (lock, cvar) = &shared_data.output_done_pair;
         let mut done = lock.lock().unwrap();
         while !*done {
             done = cvar.wait(done).unwrap();

--- a/vapoursynth/src/api.rs
+++ b/vapoursynth/src/api.rs
@@ -457,7 +457,7 @@ impl API {
     /// The caller must ensure `node` is valid.
     ///
     /// # Panics
-    /// Panics if `err_msg` is larger than `i32::max_value()`.
+    /// Panics if `err_msg` is larger than `i32::MAX`.
     #[inline]
     pub(crate) unsafe fn get_frame(
         self,
@@ -466,7 +466,7 @@ impl API {
         err_msg: &mut [c_char],
     ) -> *const ffi::VSFrameRef {
         let len = err_msg.len();
-        assert!(len <= i32::max_value() as usize);
+        assert!(len <= i32::MAX as usize);
         let len = len as i32;
 
         (self.handle.as_ref().getFrame)(n, node, err_msg.as_mut_ptr(), len)
@@ -749,7 +749,7 @@ impl API {
         append: ffi::VSPropAppendMode,
     ) -> i32 {
         let length = value.len();
-        assert!(length <= i32::max_value() as usize);
+        assert!(length <= i32::MAX as usize);
         let length = length as i32;
 
         (self.handle.as_ref().propSetData)(map, key, value.as_ptr() as _, length, append as i32)
@@ -771,7 +771,7 @@ impl API {
         value: &[i64],
     ) -> i32 {
         let length = value.len();
-        assert!(length <= i32::max_value() as usize);
+        assert!(length <= i32::MAX as usize);
         let length = length as i32;
 
         (self.handle.as_ref().propSetIntArray)(map, key, value.as_ptr(), length)
@@ -793,7 +793,7 @@ impl API {
         value: &[f64],
     ) -> i32 {
         let length = value.len();
-        assert!(length <= i32::max_value() as usize);
+        assert!(length <= i32::MAX as usize);
         let length = length as i32;
 
         (self.handle.as_ref().propSetFloatArray)(map, key, value.as_ptr(), length)
@@ -921,7 +921,7 @@ impl API {
     #[inline]
     pub(crate) unsafe fn set_video_info(self, vi: &[ffi::VSVideoInfo], node: *mut ffi::VSNode) {
         let length = vi.len();
-        assert!(length <= i32::max_value() as usize);
+        assert!(length <= i32::MAX as usize);
         let length = length as i32;
 
         (self.handle.as_ref().setVideoInfo)(vi.as_ptr(), length, node);

--- a/vapoursynth/src/api.rs
+++ b/vapoursynth/src/api.rs
@@ -199,6 +199,7 @@ impl API {
         F: FnMut(MessageType, &CStr) + Send + 'static,
     {
         struct CallbackData {
+            #[allow(clippy::type_complexity)]
             callback: Box<dyn FnMut(MessageType, &CStr) + Send + 'static>,
         }
 
@@ -258,6 +259,7 @@ impl API {
         F: FnMut(MessageType, &CStr) + Send + 'static,
     {
         struct CallbackData {
+            #[allow(clippy::type_complexity)]
             callback: Box<dyn FnMut(MessageType, &CStr) + Send + 'static>,
         }
 

--- a/vapoursynth/src/format.rs
+++ b/vapoursynth/src/format.rs
@@ -159,7 +159,7 @@ impl<'core> Format<'core> {
     #[inline]
     pub fn bits_per_sample(self) -> u8 {
         let rv = self.handle.bitsPerSample;
-        debug_assert!(rv >= 0 && rv <= i32::from(u8::max_value()));
+        debug_assert!(rv >= 0 && rv <= i32::from(u8::MAX));
         rv as u8
     }
 
@@ -168,7 +168,7 @@ impl<'core> Format<'core> {
     #[inline]
     pub fn bytes_per_sample(self) -> u8 {
         let rv = self.handle.bytesPerSample;
-        debug_assert!(rv >= 0 && rv <= i32::from(u8::max_value()));
+        debug_assert!(rv >= 0 && rv <= i32::from(u8::MAX));
         rv as u8
     }
 
@@ -176,7 +176,7 @@ impl<'core> Format<'core> {
     #[inline]
     pub fn sub_sampling_w(self) -> u8 {
         let rv = self.handle.subSamplingW;
-        debug_assert!(rv >= 0 && rv <= i32::from(u8::max_value()));
+        debug_assert!(rv >= 0 && rv <= i32::from(u8::MAX));
         rv as u8
     }
 
@@ -184,7 +184,7 @@ impl<'core> Format<'core> {
     #[inline]
     pub fn sub_sampling_h(self) -> u8 {
         let rv = self.handle.subSamplingH;
-        debug_assert!(rv >= 0 && rv <= i32::from(u8::max_value()));
+        debug_assert!(rv >= 0 && rv <= i32::from(u8::MAX));
         rv as u8
     }
 }

--- a/vapoursynth/src/frame.rs
+++ b/vapoursynth/src/frame.rs
@@ -168,8 +168,8 @@ impl<'core> FrameRefMut<'core> {
         format: Format<'core>,
         resolution: Resolution,
     ) -> Self {
-        assert!(resolution.width <= i32::max_value() as usize);
-        assert!(resolution.height <= i32::max_value() as usize);
+        assert!(resolution.width <= i32::MAX as usize);
+        assert!(resolution.height <= i32::MAX as usize);
 
         Self {
             frame: unsafe {
@@ -284,7 +284,7 @@ impl<'core> Frame<'core> {
         let ptr = self.data_ptr(plane);
 
         let offset = stride * row;
-        assert!(offset <= isize::max_value() as usize);
+        assert!(offset <= isize::MAX as usize);
         let offset = offset as isize;
 
         let row_ptr = unsafe { ptr.offset(offset) };
@@ -307,7 +307,7 @@ impl<'core> Frame<'core> {
         let ptr = self.data_ptr_mut(plane);
 
         let offset = stride * row;
-        assert!(offset <= isize::max_value() as usize);
+        assert!(offset <= isize::MAX as usize);
         let offset = offset as isize;
 
         let row_ptr = unsafe { ptr.offset(offset) };
@@ -408,7 +408,7 @@ impl<'core> Frame<'core> {
         let ptr = self.data_ptr(plane);
 
         let offset = stride * row;
-        assert!(offset <= isize::max_value() as usize);
+        assert!(offset <= isize::MAX as usize);
         let offset = offset as isize;
 
         let row_ptr = unsafe { ptr.offset(offset) };
@@ -431,7 +431,7 @@ impl<'core> Frame<'core> {
         let ptr = self.data_ptr_mut(plane);
 
         let offset = stride * row;
-        assert!(offset <= isize::max_value() as usize);
+        assert!(offset <= isize::MAX as usize);
         let offset = offset as isize;
 
         let row_ptr = unsafe { ptr.offset(offset) };

--- a/vapoursynth/src/node/mod.rs
+++ b/vapoursynth/src/node/mod.rs
@@ -137,7 +137,7 @@ impl<'core> Node<'core> {
         let mut err_buf = err_buf.into_boxed_slice();
 
         let handle =
-            unsafe { API::get_cached().get_frame(n as i32, self.handle.as_ptr(), &mut *err_buf) };
+            unsafe { API::get_cached().get_frame(n as i32, self.handle.as_ptr(), &mut err_buf) };
 
         if handle.is_null() {
             // TODO: remove this extra allocation by reusing `Box<[c_char]>`.

--- a/vapoursynth/src/node/mod.rs
+++ b/vapoursynth/src/node/mod.rs
@@ -109,9 +109,9 @@ impl<'core> Node<'core> {
     /// The `'error` lifetime is unbounded because this function always returns owned data.
     ///
     /// # Panics
-    /// Panics is `n` is greater than `i32::max_value()`.
+    /// Panics is `n` is greater than `i32::MAX`.
     pub fn get_frame<'error>(&self, n: usize) -> Result<FrameRef<'core>, GetFrameError<'error>> {
-        assert!(n <= i32::max_value() as usize);
+        assert!(n <= i32::MAX as usize);
 
         let vi = &self.info();
 
@@ -162,7 +162,7 @@ impl<'core> Node<'core> {
     /// If the callback panics, the process is aborted.
     ///
     /// # Panics
-    /// Panics is `n` is greater than `i32::max_value()`.
+    /// Panics is `n` is greater than `i32::MAX`.
     pub fn get_frame_async<F>(&self, n: usize, callback: F)
     where
         F: FnOnce(Result<FrameRef<'core>, GetFrameError>, usize, Node<'core>) + Send + 'core,
@@ -230,7 +230,7 @@ impl<'core> Node<'core> {
             }
         }
 
-        assert!(n <= i32::max_value() as usize);
+        assert!(n <= i32::MAX as usize);
         let n = n as i32;
 
         let user_data = Box::new(CallbackData {
@@ -266,9 +266,9 @@ impl<'core> Node<'core> {
     /// It is best to request frames in ascending order, i.e. `n`, `n+1`, `n+2`, etc.
     ///
     /// # Panics
-    /// Panics is `n` is greater than `i32::max_value()`.
+    /// Panics is `n` is greater than `i32::MAX`.
     pub fn request_frame_filter(&self, context: FrameContext, n: usize) {
-        assert!(n <= i32::max_value() as usize);
+        assert!(n <= i32::MAX as usize);
         let n = n as i32;
 
         unsafe {
@@ -282,9 +282,9 @@ impl<'core> Node<'core> {
     /// more than once.
     ///
     /// # Panics
-    /// Panics is `n` is greater than `i32::max_value()`.
+    /// Panics is `n` is greater than `i32::MAX`.
     pub fn get_frame_filter(&self, context: FrameContext, n: usize) -> Option<FrameRef<'core>> {
-        assert!(n <= i32::max_value() as usize);
+        assert!(n <= i32::MAX as usize);
         let n = n as i32;
 
         let ptr = unsafe { API::get_cached().get_frame_filter(n, self.ptr(), context.ptr()) };

--- a/vapoursynth/src/tests.rs
+++ b/vapoursynth/src/tests.rs
@@ -330,7 +330,7 @@ mod need_api_and_vsscript {
         verify_pixel_format(&env, 1, 32, [5f32, 42f32, 0.25f32]);
         verify_pixel_format(&env, 2, 32, [0.125f32, 10f32, 0.5f32]);
         verify_pixel_format(&env, 3, 17, [77777u32, 88888u32, 99999u32]);
-        verify_pixel_format(&env, 4, 32, [u32::max_value(), 12345u32, 65432u32]);
+        verify_pixel_format(&env, 4, 32, [u32::MAX, 12345u32, 65432u32]);
 
         #[cfg(feature = "f16-pixel-type")]
         verify_pixel_format(


### PR DESCRIPTION
This should fix all current clippy warnings. Note that I added `#[allow]`s in a few places, but I don't think those are too controversial.