### PR TITLE
Add default library paths for macOS

### DIFF
--- a/vapoursynth-sys/build.rs
+++ b/vapoursynth-sys/build.rs
@@ -7,19 +7,26 @@ fn main() {
     // Make sure the build script is re-run if our env variable is changed.
     println!("cargo:rerun-if-env-changed={}", LIBRARY_DIR_VARIABLE);
 
-    let windows = env::var("TARGET").unwrap().contains("windows");
+    // These should always be set when a build script is run
+    let target = env::var("TARGET").unwrap();
+    let host = env::var("HOST").unwrap();
 
-    // Get the default library dir on Windows.
-    let default_library_dir = if windows {
-        get_default_library_dir()
+    let targets_windows = target.contains("windows");
+    let targets_macos = target.contains("apple-darwin");
+
+    // Get the default library dir for some platforms.
+    let default_library_dir = if targets_windows {
+        get_default_windows_library_dir(target, host)
+    } else if targets_macos {
+        get_default_macos_library_dir(target, host)
     } else {
-        None
+        vec![]
     };
 
     // Library directory override or the default dir on windows.
     if let Ok(dir) = env::var(LIBRARY_DIR_VARIABLE) {
         println!("cargo:rustc-link-search=native={}", dir);
-    } else if let Some(default_library_dir) = default_library_dir {
+    } else {
         for dir in default_library_dir {
             println!("cargo:rustc-link-search=native={}", dir);
         }
@@ -31,7 +38,7 @@ fn main() {
     }
 
     if env::var("CARGO_FEATURE_VSSCRIPT_FUNCTIONS").is_ok() {
-        let vsscript_lib_name = if windows {
+        let vsscript_lib_name = if targets_windows {
             "vsscript"
         } else {
             "vapoursynth-script"
@@ -43,12 +50,10 @@ fn main() {
 
 // Returns the default library dirs on Windows.
 // The default dir is where the VapourSynth installer puts the libraries.
-fn get_default_library_dir() -> Option<impl Iterator<Item = String>> {
-    let host = env::var("HOST").ok()?;
-
+fn get_default_windows_library_dir(target: String, host: String) -> Vec<String> {
     // If the host isn't Windows we don't have %programfiles%.
     if !host.contains("windows") {
-        return None;
+        return vec![];
     }
 
     let programfiles = env::var("programfiles").into_iter();
@@ -61,20 +66,36 @@ fn get_default_library_dir() -> Option<impl Iterator<Item = String>> {
         "programfiles(x86)"
     }));
 
-    let suffix = if env::var("TARGET").ok()?.starts_with("i686") {
+    let suffix = if target.starts_with("i686") {
         "lib32"
     } else {
         "lib64"
     };
 
-    Some(programfiles.flat_map(move |programfiles| {
-        // Use both VapourSynth and VapourSynth-32 folder names.
-        ["", "-32"].iter().filter_map(move |vapoursynth_suffix| {
-            let mut path = PathBuf::from(&programfiles);
-            path.push(format!("VapourSynth{}", vapoursynth_suffix));
-            path.push("sdk");
-            path.push(suffix);
-            path.to_str().map(|s| s.to_owned())
+    programfiles
+        .flat_map(move |programfiles| {
+            // Use both VapourSynth and VapourSynth-32 folder names.
+            ["", "-32"].iter().filter_map(move |vapoursynth_suffix| {
+                let mut path = PathBuf::from(&programfiles);
+                path.push(format!("VapourSynth{}", vapoursynth_suffix));
+                path.push("sdk");
+                path.push(suffix);
+                path.to_str().map(|s| s.to_owned())
+            })
         })
-    }))
+        .collect()
+}
+
+// Returns the default library dirs on macOS when using homebrew.
+fn get_default_macos_library_dir(target: String, host: String) -> Vec<String> {
+    // If the host is not macOS/Apple, the library dirs will be different.
+    if !host.contains("apple-darwin") {
+        return vec![];
+    }
+
+    if target.starts_with("aarch64") {
+        vec![String::from("/opt/homebrew/lib/")]
+    } else {
+        vec![String::from("/usr/local/homebrew/lib/")]
+    }
 }

--- a/vapoursynth-sys/build.rs
+++ b/vapoursynth-sys/build.rs
@@ -16,9 +16,9 @@ fn main() {
 
     // Get the default library dir for some platforms.
     let default_library_dir = if targets_windows {
-        get_default_windows_library_dir(target, host)
+        get_default_windows_library_dir(&target, &host)
     } else if targets_macos {
-        get_default_macos_library_dir(target, host)
+        get_default_macos_library_dir(&target, &host)
     } else {
         vec![]
     };
@@ -50,7 +50,7 @@ fn main() {
 
 // Returns the default library dirs on Windows.
 // The default dir is where the VapourSynth installer puts the libraries.
-fn get_default_windows_library_dir(target: String, host: String) -> Vec<String> {
+fn get_default_windows_library_dir(target: &str, host: &str) -> Vec<String> {
     // If the host isn't Windows we don't have %programfiles%.
     if !host.contains("windows") {
         return vec![];
@@ -87,7 +87,7 @@ fn get_default_windows_library_dir(target: String, host: String) -> Vec<String> 
 }
 
 // Returns the homebrew library dirs on macOS.
-fn get_default_macos_library_dir(target: String, host: String) -> Vec<String> {
+fn get_default_macos_library_dir(target: &str, host: &str) -> Vec<String> {
     // If the host is not macOS/Apple, the library dirs will be different.
     if !host.contains("apple-darwin") {
         return vec![];

--- a/vapoursynth-sys/build.rs
+++ b/vapoursynth-sys/build.rs
@@ -86,13 +86,21 @@ fn get_default_windows_library_dir(target: String, host: String) -> Vec<String> 
         .collect()
 }
 
-// Returns the default library dirs on macOS when using homebrew.
+// Returns the homebrew library dirs on macOS.
 fn get_default_macos_library_dir(target: String, host: String) -> Vec<String> {
     // If the host is not macOS/Apple, the library dirs will be different.
     if !host.contains("apple-darwin") {
         return vec![];
     }
 
+    // Use $HOMEBREW_PREFIX if set and not cross-compiling
+    if host == target {
+        if let Ok(prefix) = env::var("HOMEBREW_PREFIX") {
+            return vec![format!("{}/lib", prefix)];
+        }
+    }
+
+    // Otherwise, return the default library dir
     if target.starts_with("aarch64") {
         vec![String::from("/opt/homebrew/lib/")]
     } else {


### PR DESCRIPTION
Closes #23.

I had to change the fn return type from `Option<impl Iterator<Item =  String>>` to something concrete, so I chose `Vec<String>` and used empty vectors instead of `None`. 

I did some rudimentary testing on my fork by re-enabling the macOS CI build. The tests themselves fail, but after this patch, the linking itself seems to work.

@quietvoid, testing the change would be appreciated.