### PR TITLE
Improve macro and anyhow ergonomics

### DIFF
--- a/vapoursynth/CHANGELOG.md
+++ b/vapoursynth/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.2 (2026-01-08)
+
+- Reduce the number of extra imports needed when using plugin creation macros
+- Re-export `anyhow` for convenience
+
 ## v0.5.1 (2026-01-02)
 
 - Fix compilation issue on AArch64

--- a/vapoursynth/Cargo.toml
+++ b/vapoursynth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vapoursynth"
 edition = "2024"
-version = "0.5.1"
+version = "0.5.2"
 description = "Safe Rust wrapper for VapourSynth and VSScript."
 license = "MIT/Apache-2.0"
 

--- a/vapoursynth/src/api.rs
+++ b/vapoursynth/src/api.rs
@@ -38,7 +38,7 @@ macro_rules! prop_get_something {
         #[inline]
         pub(crate) unsafe fn $name(
             self,
-            map: &ffi::VSMap,
+            map: &$crate::ffi::VSMap,
             key: *const c_char,
             index: i32,
             error: &mut i32,
@@ -53,10 +53,10 @@ macro_rules! prop_set_something {
         #[inline]
         pub(crate) unsafe fn $name(
             self,
-            map: &mut ffi::VSMap,
+            map: &mut $crate::ffi::VSMap,
             key: *const c_char,
             value: $type,
-            append: ffi::VSMapAppendMode,
+            append: $crate::ffi::VSMapAppendMode,
         ) -> i32 {
             (self.handle.as_ref().$func.unwrap())(map, key, value, append as i32)
         }

--- a/vapoursynth/src/lib.rs
+++ b/vapoursynth/src/lib.rs
@@ -179,4 +179,6 @@ pub mod prelude {
     pub use super::vsscript::{self, Environment, EvalFlags};
 }
 
+pub use anyhow;
+
 mod tests;

--- a/vapoursynth/src/map/iterators.rs
+++ b/vapoursynth/src/map/iterators.rs
@@ -54,17 +54,20 @@ pub struct ValueIter<'map, 'elem: 'map, T> {
 
 macro_rules! impl_value_iter {
     ($value_type:path, $type:ty, $func:ident) => {
-        impl<'map, 'elem> ValueIter<'map, 'elem, $type> {
+        impl<'map, 'elem> $crate::map::ValueIter<'map, 'elem, $type> {
             /// Creates a `ValueIter` from the given `map` and `key`.
             ///
             /// # Safety
             /// The caller must ensure `key` is valid.
             #[inline]
-            pub(crate) unsafe fn new(map: &'map Map<'elem>, key: CString) -> Result<Self> {
+            pub(crate) unsafe fn new(
+                map: &'map $crate::prelude::Map<'elem>,
+                key: CString,
+            ) -> $crate::map::Result<Self> {
                 // Check if the value type is correct.
                 match map.value_type_raw_unchecked(&key)? {
                     $value_type => {}
-                    _ => return Err(Error::WrongValueType),
+                    _ => return Err($crate::map::Error::WrongValueType),
                 };
 
                 let count = map.value_count_raw_unchecked(&key)? as i32;
@@ -73,12 +76,12 @@ macro_rules! impl_value_iter {
                     key,
                     count,
                     index: 0,
-                    _variance: PhantomData,
+                    _variance: std::marker::PhantomData,
                 })
             }
         }
 
-        impl<'map, 'elem> Iterator for ValueIter<'map, 'elem, $type> {
+        impl<'map, 'elem> std::iter::Iterator for $crate::map::ValueIter<'map, 'elem, $type> {
             type Item = $type;
 
             #[inline]
@@ -100,7 +103,10 @@ macro_rules! impl_value_iter {
             }
         }
 
-        impl<'map, 'elem> ExactSizeIterator for ValueIter<'map, 'elem, $type> {}
+        impl<'map, 'elem> std::iter::ExactSizeIterator
+            for $crate::map::ValueIter<'map, 'elem, $type>
+        {
+        }
     };
 }
 

--- a/vapoursynth/src/plugins/mod.rs
+++ b/vapoursynth/src/plugins/mod.rs
@@ -1,6 +1,6 @@
 //! Things related to making VapourSynth plugins.
 
-use anyhow::Error;
+use anyhow::Result;
 
 use crate::api::API;
 use crate::core::CoreRef;
@@ -94,7 +94,7 @@ pub trait FilterFunction: Send + Sync {
         api: API,
         core: CoreRef<'core>,
         args: &Map<'core>,
-    ) -> Result<Option<Box<dyn Filter<'core> + 'core>>, Error>;
+    ) -> Result<Option<Box<dyn Filter<'core> + 'core>>>;
 }
 
 /// A filter interface.
@@ -122,7 +122,7 @@ pub trait Filter<'core>: Send + Sync {
         core: CoreRef<'core>,
         context: FrameContext,
         n: usize,
-    ) -> Result<Option<FrameRef<'core>>, Error>;
+    ) -> Result<Option<FrameRef<'core>>>;
 
     /// Returns the requested frame.
     ///
@@ -139,7 +139,7 @@ pub trait Filter<'core>: Send + Sync {
         core: CoreRef<'core>,
         context: FrameContext,
         n: usize,
-    ) -> Result<FrameRef<'core>, Error>;
+    ) -> Result<FrameRef<'core>>;
 }
 
 /// An internal trait representing a filter argument type.
@@ -432,10 +432,10 @@ macro_rules! make_filter_function {
             #[inline]
             fn create<'core>(
                 &self,
-                api: API,
-                core: CoreRef<'core>,
-                args: &Map<'core>,
-            ) -> Result<Option<Box<dyn $crate::plugins::Filter<'core> + 'core>>, Error> {
+                api: $crate::prelude::API,
+                core: $crate::core::CoreRef<'core>,
+                args: &$crate::prelude::Map<'core>,
+            ) -> $crate::anyhow::Result<Option<Box<dyn $crate::plugins::Filter<'core> + 'core>>> {
                 $create_fn_name(
                     api,
                     core,


### PR DESCRIPTION
Reduces the number of additional `use` statements needed when using plugin creation macros. Re-exports `anyhow` for convenience, so users do not need to add it to their `Cargo.toml` if they are not using it elsewhere.