### PR TITLE
fix: turn on r73 compat by default

### DIFF
--- a/vapoursynth/Cargo.toml
+++ b/vapoursynth/Cargo.toml
@@ -30,7 +30,7 @@ default-features = false
 features = ["std"]
 
 [features]
-default = []
+default = ["vsscript-r73-compat"]
 # Enable the half::f16 type to be used for frame pixel data.
 f16-pixel-type = ["half"]
 


### PR DESCRIPTION
This was an accidental breaking change. The r73 compat flag needs to be enabled in order to maintain compatibility with the 0.5.x line. This flag will be removed from the defaults in a future semver major release.