### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/vapoursynth.yml
+++ b/.github/workflows/vapoursynth.yml
@@ -49,6 +49,7 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: 3.14
+          enable-cache: false
           activate-environment: ${{ matrix.version != '73' }}
 
       - name: Install VapourSynth Python Package
@@ -122,6 +123,7 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: 3.14
+          enable-cache: false
           activate-environment: ${{ matrix.version != '73' }}
 
       - name: Install VapourSynth Portable

--- a/.github/workflows/vapoursynth.yml
+++ b/.github/workflows/vapoursynth.yml
@@ -6,7 +6,7 @@ jobs:
   clippy-rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -43,10 +43,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: 3.14
           activate-environment: ${{ matrix.version != '73' }}
@@ -116,10 +116,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: 3.14
           activate-environment: ${{ matrix.version != '73' }}

--- a/.github/workflows/vapoursynth.yml
+++ b/.github/workflows/vapoursynth.yml
@@ -79,11 +79,11 @@ jobs:
       - name: Run sample-plugin tests
         run: |
           cd sample-plugin
-          cargo build --verbose
-          cargo run ${{ matrix.version == '73' && '--features vsscript-r73-compat' }} --verbose --bin test
+          cargo build
+          cargo run ${{ matrix.version == '73' && '--features vsscript-r73-compat' }} --bin test
       - name: Run doc
         run: |
-          cargo doc --all-features --verbose
+          cargo doc --all-features
       - name: Copy index into the target directory
         if: matrix.toolchain == 'stable-x86_64-unknown-linux-gnu'
         run: |
@@ -153,12 +153,12 @@ jobs:
       - name: Build sample-plugin
         run: |
           cd sample-plugin
-          cargo build --verbose
+          cargo build
       - name: Run sample-plugin tests
         # https://github.com/rust-lang/rust/issues/50176
         run: |
           $Env:Path += ";C:\Program Files\VapourSynth;"
           cd sample-plugin
-          cargo run --verbose --bin test
+          cargo run --bin test
       - name: Run doc
-        run: cargo doc --all-features --verbose
+        run: cargo doc --all-features

--- a/build/run-tests.py
+++ b/build/run-tests.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
         try:
             subprocess.run(
-                ["cargo", "test", "--verbose", "--features", features_string],
+                ["cargo", "test", "--features", features_string],
                 check=True,
             )
         except subprocess.CalledProcessError:


### PR DESCRIPTION
- Bumps actions/checkout from v4 to v6
- Bumps setup-uv from v7 to v8
  - Note: `@v8` does not work, for security reasons there's no "rolling" release tag anymore but just fixed commits or X.Y.Z (full version) tags. Explanation in their [8.0 release](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0)
  - disable uv cache because it A: [barely does anything for us](https://github.com/FreezyLemon/vapoursynth-rs/actions/runs/26637466781/job/78501324245) and B: causes warnings with default settings (it expects a Python project file structure which we obviously don't have)
- remove `--verbose` flag from cargo build/run commands. The extra output clutters up the logs and is usually in the way. If needed it can always be re-enabled on a feature branch for debugging